### PR TITLE
Potential fix for code scanning alert no. 9: Incorrect conversion between integer types

### DIFF
--- a/cmd/devp2p/discv4cmd.go
+++ b/cmd/devp2p/discv4cmd.go
@@ -336,7 +336,7 @@ func parseExtAddr(spec string) (ip net.IP, port int, ok bool) {
 		return nil, 0, false
 	}
 	port, err = strconv.Atoi(portstr)
-	if err != nil {
+	if err != nil || port < 0 || port > 65535 {
 		return nil, 0, false
 	}
 	return ip, port, true

--- a/p2p/enode/localnode.go
+++ b/p2p/enode/localnode.go
@@ -205,6 +205,10 @@ func (ln *LocalNode) SetFallbackIP(ip net.IP) {
 // SetFallbackUDP sets the last-resort UDP-on-IPv4 port. This port is used
 // if no endpoint prediction can be made.
 func (ln *LocalNode) SetFallbackUDP(port int) {
+	if port < 0 || port > 65535 {
+		log.Error("Invalid port value, must be in range 0-65535", "port", port)
+		return
+	}
 	ln.mu.Lock()
 	defer ln.mu.Unlock()
 


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/go-ethereum/security/code-scanning/9](https://github.com/roseteromeo56/go-ethereum/security/code-scanning/9)

To fix the issue, we need to ensure that the `port` value is within the valid range for `uint16` (0 to 65535) before converting it. This can be achieved by adding an explicit bounds check in the `SetFallbackUDP` function. If the value is out of bounds, the function should handle it gracefully, such as by logging an error or using a default value.

Additionally, the `parseExtAddr` function in `cmd/devp2p/discv4cmd.go` should also validate the `port` value to ensure it is within the valid range before returning it. This provides an additional layer of protection and ensures that invalid values are caught early.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
