### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,6 +7,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/go-ethereum/security/code-scanning/1](https://github.com/roseteromeo56/go-ethereum/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out the repository, caching build tools, setting up Go, and running linters and tests, it only requires `contents: read` permissions. This will ensure that the workflow has the minimum necessary access to perform its tasks.

The `permissions` block will be added at the root level of the workflow to apply to all jobs (`lint` and `build`). This avoids redundancy and ensures consistency across the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
