### PR TITLE
Potential fix for code scanning alert no. 8: Incorrect conversion between integer types

### DIFF
--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
 	"strconv"
@@ -58,8 +59,14 @@ func (b *Long) UnmarshalGraphQL(input interface{}) error {
 		if strings.HasPrefix(input, "0x") {
 			// apply leniency and support hex representations of longs.
 			value, err := hexutil.DecodeUint64(input)
+			if err != nil {
+				return err
+			}
+			if value > math.MaxInt64 {
+				return fmt.Errorf("value %d exceeds int64 range", value)
+			}
 			*b = Long(value)
-			return err
+			return nil
 		} else {
 			value, err := strconv.ParseInt(input, 10, 64)
 			*b = Long(value)


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/go-ethereum/security/code-scanning/8](https://github.com/roseteromeo56/go-ethereum/security/code-scanning/8)

To fix the issue, we need to ensure that the `uint64` value returned by `hexutil.DecodeUint64` is within the range of `int64` before performing the conversion. This can be achieved by adding an explicit bounds check. If the value exceeds `math.MaxInt64`, an error should be returned to indicate that the input is invalid.

The fix involves:
1. Importing the `math` package to access the `math.MaxInt64` constant.
2. Adding a conditional check after calling `hexutil.DecodeUint64` to verify that the value is less than or equal to `math.MaxInt64`.
3. Returning an appropriate error if the value is out of bounds.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
