### PR TITLE
Potential fix for code scanning alert no. 5: Size computation for allocation may overflow

### DIFF
--- a/common/hexutil/hexutil.go
+++ b/common/hexutil/hexutil.go
@@ -82,6 +82,9 @@ func MustDecode(input string) []byte {
 
 // Encode encodes b as a hex string with 0x prefix.
 func Encode(b []byte) string {
+	if len(b) > (int(^uint(0) >> 1))/2 {
+		panic("input too large to encode as hex string")
+	}
 	enc := make([]byte, len(b)*2+2)
 	copy(enc, "0x")
 	hex.Encode(enc[2:], b)


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/go-ethereum/security/code-scanning/5](https://github.com/roseteromeo56/go-ethereum/security/code-scanning/5)

To fix the issue, we need to ensure that the size computation `len(b)*2` does not overflow. This can be achieved by validating the length of `b` before performing the multiplication. Specifically:
1. Check if `len(b)` exceeds a safe threshold (e.g., `math.MaxInt/2` for 32-bit or 64-bit systems).
2. If the length is too large, return an error or handle the situation gracefully.
3. Proceed with the allocation only if the size computation is safe.

The fix will involve modifying the `Encode` function in `common/hexutil/hexutil.go` to include this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
