### PR TITLE
Potential fix for code scanning alert no. 4: Size computation for allocation may overflow

### DIFF
--- a/accounts/usbwallet/trezor.go
+++ b/accounts/usbwallet/trezor.go
@@ -294,6 +294,9 @@ func (w *trezorDriver) trezorExchange(req proto.Message, results ...proto.Messag
 	if err != nil {
 		return 0, err
 	}
+	if len(data) > math.MaxInt-8 {
+		return 0, errors.New("serialized data too large")
+	}
 	payload := make([]byte, 8+len(data))
 	copy(payload, []byte{0x23, 0x23})
 	binary.BigEndian.PutUint16(payload[2:], trezor.Type(req))


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/go-ethereum/security/code-scanning/4](https://github.com/roseteromeo56/go-ethereum/security/code-scanning/4)

To fix the issue, we need to validate the size of the serialized data (`len(data)`) before performing arithmetic operations or memory allocation. Specifically:
1. Introduce a maximum allowable size for the serialized data to ensure it fits within the bounds of an `int` and avoids overflow.
2. Check the size of `data` after serialization and return an error if it exceeds the maximum allowable size.
3. Proceed with the allocation and operations only if the size is within safe limits.

The fix will involve adding a size check after `proto.Marshal(req)` and before the computation of `payload`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
