### PR TITLE
Potential fix for code scanning alert no. 11: Clear-text logging of sensitive information

### DIFF
--- a/signer/core/cliui.go
+++ b/signer/core/cliui.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -33,8 +34,9 @@ import (
 
 // sanitizeMessage redacts sensitive information from the input string.
 func sanitizeMessage(message string) string {
-	// Example: Replace occurrences of "password: <value>" with "password: [REDACTED]"
-	return strings.ReplaceAll(message, "password:", "password: [REDACTED]")
+	// Use regular expressions to redact sensitive information.
+	re := regexp.MustCompile(`(?i)(password\s*:\s*\S+|private\s*key\s*:\s*\S+|email\s*:\s*\S+@\S+)`)
+	return re.ReplaceAllString(message, "[REDACTED]")
 }
 
 type CommandlineUI struct {


### PR DESCRIPTION
Potential fix for [https://github.com/roseteromeo56/go-ethereum/security/code-scanning/11](https://github.com/roseteromeo56/go-ethereum/security/code-scanning/11)

To address the issue, we need to enhance the `sanitizeMessage` function to comprehensively redact sensitive information, including passwords and other potential sensitive data. This can be achieved by using regular expressions to identify and redact sensitive patterns, such as email addresses, private keys, or any other identifiable sensitive data. Additionally, we should ensure that any sensitive data passed to `ShowInfo` is sanitized before logging.

1. Update the `sanitizeMessage` function in `signer/core/cliui.go` to use regular expressions for more robust redaction of sensitive data.
2. Ensure that all calls to `ShowInfo` pass sanitized messages, and review other logging methods for similar issues.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
